### PR TITLE
bws-talos: Updated Talos provider version.

### DIFF
--- a/bws-talos/versions.tf
+++ b/bws-talos/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     talos = {
       source  = "siderolabs/talos"
-      version = "0.7.1"
+      version = "0.9.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
This fixes the following version conflict error:

"
Error: Failed to query available provider packages Could not retrieve the list of available versions for provider siderolabs/talos: no available releases match the given constraints 0.7.1, 0.9.0 To see which modules are currently depending on siderolabs/talos and what versions are specified, run the following command: terraform providers
"

Relates to: https://github.com/valiton-k8s-blueprints/terraform/pull/19